### PR TITLE
Prevent overworld from unloading.

### DIFF
--- a/src/main/java/dmillerw/time/world/WorldProviderOverworld.java
+++ b/src/main/java/dmillerw/time/world/WorldProviderOverworld.java
@@ -13,9 +13,9 @@ public class WorldProviderOverworld extends WorldProviderSurface {
 	public static void overrideDefault() {
 		DimensionManager.unregisterProviderType(DimensionManager.getProviderType(0));
 		if (Loader.isModLoaded("BiomesOPlenty")) {
-            DimensionManager.registerProviderType(0, WorldProviderOverworldBOP.class, false);
+            DimensionManager.registerProviderType(0, WorldProviderOverworldBOP.class, true);
         } else {
-            DimensionManager.registerProviderType(0, WorldProviderOverworld.class, false);
+            DimensionManager.registerProviderType(0, WorldProviderOverworld.class, true);
         }
 	}
 


### PR DESCRIPTION
The second parameter to registerProviderType is "keepLoaded". Minecraft assumes that dimension 0 will always be loaded so this should be true.
